### PR TITLE
feat: Implement role-based access control

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -44,6 +44,7 @@ class HandleInertiaRequests extends Middleware
             'quote' => ['message' => trim($message), 'author' => trim($author)],
             'auth' => [
                 'user' => $request->user(),
+                'permissions' => $request->user() ? $request->user()->getAllPermissions()->pluck('name') : [],
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
         ];

--- a/app/Http/Middleware/PermissionMiddleware.php
+++ b/app/Http/Middleware/PermissionMiddleware.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Support\Facades\Auth;
+
+class PermissionMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next, $permission, $guard = null): Response
+    {
+        $authGuard = Auth::guard($guard);
+
+        if ($authGuard->guest()) {
+            abort(403);
+        }
+
+        $permissions = is_array($permission)
+            ? $permission
+            : explode('|', $permission);
+
+        foreach ($permissions as $p) {
+            if ($authGuard->user()->can($p)) {
+                return $next($request);
+            }
+        }
+
+        abort(403);
+    }
+}

--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Support\Facades\Auth;
+
+class RoleMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next, $role, $guard = null): Response
+    {
+        $authGuard = Auth::guard($guard);
+
+        if ($authGuard->guest()) {
+            abort(403);
+        }
+
+        $roles = is_array($role)
+            ? $role
+            : explode('|', $role);
+
+        if (! $authGuard->user()->hasAnyRole($roles)) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -21,6 +21,11 @@ return Application::configure(basePath: dirname(__DIR__))
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,
         ]);
+
+        $middleware->alias([
+            'role' => \App\Http\Middleware\RoleMiddleware::class,
+            'permission' => \App\Http\Middleware\PermissionMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -34,5 +34,7 @@ class DatabaseSeeder extends Seeder
         );
 
         $user->assignRole('Super Admin');
+
+        $this->call(PermissionsSeeder::class);
     }
 }

--- a/database/seeders/PermissionsSeeder.php
+++ b/database/seeders/PermissionsSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\RolesEnum;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class PermissionsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $accessSettings = Permission::firstOrCreate(['name' => 'access-settings']);
+
+        $superAdminRole = Role::firstOrCreate(['name' => RolesEnum::SUPER_ADMIN->value]);
+        $adminRole = Role::firstOrCreate(['name' => RolesEnum::ADMIN->value]);
+
+        $superAdminRole->givePermissionTo($accessSettings);
+        $adminRole->givePermissionTo($accessSettings);
+    }
+}

--- a/resources/js/components/user-menu-content.tsx
+++ b/resources/js/components/user-menu-content.tsx
@@ -8,8 +8,8 @@ import { UserInfo } from '@/components/user-info';
 import { useMobileNavigation } from '@/hooks/use-mobile-navigation';
 import { logout } from '@/routes';
 import { edit } from '@/routes/profile';
-import { type User } from '@/types';
-import { Link, router } from '@inertiajs/react';
+import { type SharedData, type User } from '@/types';
+import { Link, router, usePage } from '@inertiajs/react';
 import { LogOut, Settings } from 'lucide-react';
 
 interface UserMenuContentProps {
@@ -17,6 +17,7 @@ interface UserMenuContentProps {
 }
 
 export function UserMenuContent({ user }: UserMenuContentProps) {
+    const { auth } = usePage<SharedData>().props;
     const cleanup = useMobileNavigation();
 
     const handleLogout = () => {
@@ -33,18 +34,20 @@ export function UserMenuContent({ user }: UserMenuContentProps) {
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
-                <DropdownMenuItem asChild>
-                    <Link
-                        className="block w-full"
-                        href={edit()}
-                        as="button"
-                        prefetch
-                        onClick={cleanup}
-                    >
-                        <Settings className="mr-2" />
-                        Settings
-                    </Link>
-                </DropdownMenuItem>
+                {auth.permissions.includes('access-settings') && (
+                    <DropdownMenuItem asChild>
+                        <Link
+                            className="block w-full"
+                            href={edit()}
+                            as="button"
+                            prefetch
+                            onClick={cleanup}
+                        >
+                            <Settings className="mr-2" />
+                            Settings
+                        </Link>
+                    </DropdownMenuItem>
+                )}
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild>

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -7,7 +7,7 @@ use App\Http\Controllers\Settings\TwoFactorAuthenticationController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
-Route::middleware(['auth'])->group(function () {
+Route::middleware(['auth', 'permission:access-settings'])->group(function () {
     Route::redirect('settings', '/settings/profile');
 
     Route::get('settings/profile', [ProfileController::class, 'edit'])->name('profile.edit');

--- a/tests/Feature/PermissionsTest.php
+++ b/tests/Feature/PermissionsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Enums\RolesEnum;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class PermissionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create roles and permissions
+        $this->artisan('db:seed');
+    }
+
+    public function test_user_with_access_settings_permission_can_access_settings_page()
+    {
+        $user = User::factory()->create();
+        $user->assignRole(RolesEnum::ADMIN->value);
+
+        $response = $this->actingAs($user)->get(route('profile.edit'));
+
+        $response->assertStatus(200);
+    }
+
+    public function test_user_without_access_settings_permission_cannot_access_settings_page()
+    {
+        $user = User::factory()->create();
+        $user->assignRole(RolesEnum::FREE->value);
+
+        $response = $this->actingAs($user)->get(route('profile.edit'));
+
+        $response->assertStatus(403);
+    }
+
+    public function test_settings_link_is_visible_for_user_with_permission()
+    {
+        $user = User::factory()->create();
+        $user->assignRole(RolesEnum::ADMIN->value);
+
+        $response = $this->actingAs($user)->get(route('dashboard'));
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('dashboard')
+            ->where('auth.permissions', fn ($permissions) => in_array('access-settings', $permissions))
+        );
+    }
+
+    public function test_settings_link_is_hidden_for_user_without_permission()
+    {
+        $user = User::factory()->create();
+        $user->assignRole(RolesEnum::FREE->value);
+
+        $response = $this->actingAs($user)->get(route('dashboard'));
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('dashboard')
+            ->where('auth.permissions', fn ($permissions) => !in_array('access-settings', $permissions))
+        );
+    }
+}


### PR DESCRIPTION
This commit introduces a role and permission-based access control system using the `spatie/laravel-permission` package.

Key changes include:
- Creation of `RoleMiddleware` and `PermissionMiddleware` to protect routes.
- A `PermissionsSeeder` to create an `access-settings` permission and assign it to the `Super Admin` and `Admin` roles.
- The settings routes are now protected by the `permission:access-settings` middleware.
- User permissions are shared with the Inertia frontend.
- The "Settings" link in the user menu is now only visible to users with the `access-settings` permission.
- A feature test has been added to verify the new functionality.

Note: I was unable to run the tests or the code formatter due to issues with the environment (`php`, `composer`, and `pint` not being in the `PATH`). The code has been written with high confidence and reviewed successfully.