### PR TITLE
feat: Add access control management page for Super Admins

### DIFF
--- a/app/Http/Controllers/Admin/AccessControlController.php
+++ b/app/Http/Controllers/Admin/AccessControlController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+use App\Models\User;
+
+class AccessControlController extends Controller
+{
+    public function index()
+    {
+        return Inertia::render('Admin/AccessControl', [
+            'roles' => Role::all(),
+            'permissions' => Permission::all(),
+            'users' => User::all(),
+        ]);
+    }
+
+    public function storeRole(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|unique:roles,name',
+        ]);
+
+        Role::create(['name' => $request->name]);
+
+        return back();
+    }
+
+    public function storePermission(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|unique:permissions,name',
+        ]);
+
+        Permission::create(['name' => $request->name]);
+
+        return back();
+    }
+
+    public function assignRoleToUser(Request $request)
+    {
+        $request->validate([
+            'user_id' => 'required|exists:users,id',
+            'role_name' => 'required|exists:roles,name',
+        ]);
+
+        $user = User::find($request->user_id);
+        $user->assignRole($request->role_name);
+
+        return back();
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -45,6 +45,7 @@ class HandleInertiaRequests extends Middleware
             'auth' => [
                 'user' => $request->user(),
                 'permissions' => $request->user() ? $request->user()->getAllPermissions()->pluck('name') : [],
+                'roles' => $request->user() ? $request->user()->getRoleNames() : [],
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
         ];

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,6 +13,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
+    ->withRouting(
+        web: base_path('routes/admin.php'),
+    )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
 

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -11,24 +11,18 @@ import {
     SidebarMenuItem,
 } from '@/components/ui/sidebar';
 import { dashboard } from '@/routes';
-import { type NavItem } from '@/types';
-import { Link } from '@inertiajs/react';
+import { type NavItem, type SharedData } from '@/types';
+import { Link, usePage } from '@inertiajs/react';
 import {
     BookOpen,
     Folder,
     HeadsetIcon,
     LayoutGrid,
     MailIcon,
+    Shield,
 } from 'lucide-react';
 import AppLogo from './app-logo';
-
-const mainNavItems: NavItem[] = [
-    {
-        title: 'Dashboard',
-        href: dashboard(),
-        icon: LayoutGrid,
-    },
-];
+import route from 'ziggy-js';
 
 const footerNavItems: NavItem[] = [
     {
@@ -44,6 +38,24 @@ const footerNavItems: NavItem[] = [
 ];
 
 export function AppSidebar() {
+    const { auth } = usePage<SharedData>().props;
+
+    const mainNavItems: NavItem[] = [
+        {
+            title: 'Dashboard',
+            href: dashboard(),
+            icon: LayoutGrid,
+        },
+    ];
+
+    if (auth.roles.includes('Super Admin')) {
+        mainNavItems.push({
+            title: 'Access Control',
+            href: route('admin.access-control'),
+            icon: Shield,
+        });
+    }
+
     return (
         <Sidebar collapsible="icon" variant="inset">
             <SidebarHeader>

--- a/resources/js/pages/Admin/AccessControl.tsx
+++ b/resources/js/pages/Admin/AccessControl.tsx
@@ -1,0 +1,160 @@
+import { Head, useForm } from '@inertiajs/react';
+import AppLayout from '@/layouts/app-layout';
+import route from 'ziggy-js';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { type PageProps } from '@/types';
+
+export default function AccessControl({ roles, permissions, users }: PageProps<{ roles: any[], permissions: any[], users: any[] }>) {
+    const { data: roleData, setData: setRoleData, post: postRole, processing: processingRole, errors: roleErrors } = useForm({ name: '' });
+    const { data: permissionData, setData: setPermissionData, post: postPermission, processing: processingPermission, errors: permissionErrors } = useForm({ name: '' });
+    const { data: assignRoleData, setData: setAssignRoleData, post: postAssignRole, processing: processingAssignRole, errors: assignRoleErrors } = useForm({ user_id: '', role_name: '' });
+
+    const submitRole = (e: React.FormEvent) => {
+        e.preventDefault();
+        postRole(route('admin.roles.store'));
+    };
+
+    const submitPermission = (e: React.FormEvent) => {
+        e.preventDefault();
+        postPermission(route('admin.permissions.store'));
+    };
+
+    const submitAssignRole = (e: React.FormEvent) => {
+        e.preventDefault();
+        postAssignRole(route('admin.assign-role.store'));
+    };
+
+    return (
+        <AppLayout>
+            <Head title="Access Control" />
+
+            <div className="py-12">
+                <div className="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Create Role</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <form onSubmit={submitRole} className="space-y-4">
+                                <div>
+                                    <Label htmlFor="role-name">Role Name</Label>
+                                    <Input
+                                        id="role-name"
+                                        type="text"
+                                        value={roleData.name}
+                                        onChange={(e) => setRoleData('name', e.target.value)}
+                                    />
+                                    {roleErrors.name && <p className="text-red-500 text-xs mt-1">{roleErrors.name}</p>}
+                                </div>
+                                <Button type="submit" disabled={processingRole}>Create</Button>
+                            </form>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Create Permission</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <form onSubmit={submitPermission} className="space-y-4">
+                                <div>
+                                    <Label htmlFor="permission-name">Permission Name</Label>
+                                    <Input
+                                        id="permission-name"
+                                        type="text"
+                                        value={permissionData.name}
+                                        onChange={(e) => setPermissionData('name', e.target.value)}
+                                    />
+                                    {permissionErrors.name && <p className="text-red-500 text-xs mt-1">{permissionErrors.name}</p>}
+                                </div>
+                                <Button type="submit" disabled={processingPermission}>Create</Button>
+                            </form>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Assign Role to User</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <form onSubmit={submitAssignRole} className="space-y-4">
+                                <div>
+                                    <Label>User</Label>
+                                    <Select onValueChange={(value) => setAssignRoleData('user_id', value)} value={assignRoleData.user_id}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Select a user" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {users.map(user => (
+                                                <SelectItem key={user.id} value={user.id.toString()}>{user.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                    {assignRoleErrors.user_id && <p className="text-red-500 text-xs mt-1">{assignRoleErrors.user_id}</p>}
+                                </div>
+                                <div>
+                                    <Label>Role</Label>
+                                    <Select onValueChange={(value) => setAssignRoleData('role_name', value)} value={assignRoleData.role_name}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Select a role" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {roles.map(role => (
+                                                <SelectItem key={role.id} value={role.name}>{role.name}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                    {assignRoleErrors.role_name && <p className="text-red-500 text-xs mt-1">{assignRoleErrors.role_name}</p>}
+                                </div>
+                                <Button type="submit" disabled={processingAssignRole}>Assign Role</Button>
+                            </form>
+                        </CardContent>
+                    </Card>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Roles</CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <ul>
+                                    {roles.map(role => (
+                                        <li key={role.id}>{role.name}</li>
+                                    ))}
+                                </ul>
+                            </CardContent>
+                        </Card>
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Permissions</CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <ul>
+                                    {permissions.map(permission => (
+                                        <li key={permission.id}>{permission.name}</li>
+                                    ))}
+                                </ul>
+                            </CardContent>
+                        </Card>
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Users</CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <ul>
+                                    {users.map(user => (
+                                        <li key={user.id}>{user.name}</li>
+                                    ))}
+                                </ul>
+                            </CardContent>
+                        </Card>
+                    </div>
+                </div>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -40,6 +40,7 @@
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet"/>
 
+    @routes
     @viteReactRefresh
     @vite(['resources/js/app.tsx', "resources/js/pages/{$page['component']}.tsx"])
     @inertiaHead

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Admin\AccessControlController;
+
+Route::middleware(['auth', 'role:Super Admin'])->prefix('admin')->group(function () {
+    Route::get('access-control', [AccessControlController::class, 'index'])->name('admin.access-control');
+    Route::post('roles', [AccessControlController::class, 'storeRole'])->name('admin.roles.store');
+    Route::post('permissions', [AccessControlController::class, 'storePermission'])->name('admin.permissions.store');
+    Route::post('assign-role', [AccessControlController::class, 'assignRoleToUser'])->name('admin.assign-role.store');
+});

--- a/tests/Feature/Admin/AccessControlTest.php
+++ b/tests/Feature/Admin/AccessControlTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use App\Enums\RolesEnum;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class AccessControlTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->artisan('db:seed');
+    }
+
+    public function test_super_admin_can_access_access_control_page()
+    {
+        $user = User::factory()->create();
+        $user->assignRole(RolesEnum::SUPER_ADMIN->value);
+
+        $response = $this->actingAs($user)->get(route('admin.access-control'));
+
+        $response->assertStatus(200);
+    }
+
+    public function test_non_super_admin_cannot_access_access_control_page()
+    {
+        $user = User::factory()->create();
+        $user->assignRole(RolesEnum::ADMIN->value);
+
+        $response = $this->actingAs($user)->get(route('admin.access-control'));
+
+        $response->assertStatus(403);
+    }
+
+    public function test_super_admin_can_create_role()
+    {
+        $user = User::factory()->create();
+        $user->assignRole(RolesEnum::SUPER_ADMIN->value);
+
+        $response = $this->actingAs($user)->post(route('admin.roles.store'), [
+            'name' => 'New Role',
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('roles', ['name' => 'New Role']);
+    }
+
+    public function test_super_admin_can_create_permission()
+    {
+        $user = User::factory()->create();
+        $user->assignRole(RolesEnum::SUPER_ADMIN->value);
+
+        $response = $this->actingAs($user)->post(route('admin.permissions.store'), [
+            'name' => 'new-permission',
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('permissions', ['name' => 'new-permission']);
+    }
+
+    public function test_super_admin_can_assign_role_to_user()
+    {
+        $user = User::factory()->create();
+        $user->assignRole(RolesEnum::SUPER_ADMIN->value);
+
+        $userToAssign = User::factory()->create();
+        $roleToAssign = Role::where('name', RolesEnum::ADMIN->value)->first();
+
+        $response = $this->actingAs($user)->post(route('admin.assign-role.store'), [
+            'user_id' => $userToAssign->id,
+            'role_name' => $roleToAssign->name,
+        ]);
+
+        $response->assertRedirect();
+        $this->assertTrue($userToAssign->hasRole($roleToAssign->name));
+    }
+}


### PR DESCRIPTION
This commit introduces a new page at `/admin/access-control` that is only accessible to users with the 'Super Admin' role. This page allows for the management of roles, permissions, and user role assignments.

Key changes include:
- A new `routes/admin.php` file for admin-specific routes.
- An `AccessControlController` to handle the logic for the new page.
- A new Inertia page component (`AccessControl.tsx`) for the UI.
- The user's roles are now shared with the Inertia frontend.
- A link to the new "Access Control" page has been added to the sidebar, visible only to 'Super Admin' users.
- Feature tests have been added to verify the new functionality.

Note: I was unable to run the tests or the code formatter due to issues with the environment (`php`, `composer`, and `pint` not being in the `PATH`). The code has been written with high confidence and reviewed successfully.