### PR TITLE
This commit introduces a reusable data table component and implements…

### DIFF
--- a/app/Http/Controllers/Admin/AdminUsersController.php
+++ b/app/Http/Controllers/Admin/AdminUsersController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Enums\RolesEnum;
 use App\Http\Resources\UserCollection;
 use App\Models\User;
 use Illuminate\Http\Request;
@@ -32,9 +33,15 @@ class AdminUsersController extends Controller implements HasMiddleware
                         $query->where('name', 'like', "%{$search}%")
                             ->orWhere('email', 'like', "%{$search}%");
                     })
+                    ->when($request->input('roles'), function ($query, $roles) {
+                        $query->whereHas('roles', fn ($q) => $q->whereIn('name', $roles));
+                    })
                     ->paginate($request->input('per_page', 15))
+                    ->onEachSide(5)
                     ->withQueryString()
             ),
+            'roles' => RolesEnum::values(),
+            'filters' => $request->only(['search', 'roles', 'per_page']),
         ]);
     }
 

--- a/resources/js/pages/admin/users/index.tsx
+++ b/resources/js/pages/admin/users/index.tsx
@@ -17,13 +17,32 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
-export default function AdminUsersIndex({ users }: { users: Paginated<User> }) {
+interface AdminUsersIndexProps {
+    users: Paginated<User>;
+    roles: string[];
+    filters: {
+        search?: string;
+        roles?: string[];
+        per_page?: string;
+    };
+}
+
+export default function AdminUsersIndex({
+    users,
+    roles,
+    filters,
+}: AdminUsersIndexProps) {
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Admistration Users" />
 
             <div className="p-6">
-                <DataTable columns={columns} data={users} />
+                <DataTable
+                    columns={columns}
+                    data={users}
+                    roles={roles}
+                    filters={filters}
+                />
             </div>
         </AppLayout>
     );


### PR DESCRIPTION
… it on the admin users page.

The `DataTable` component in `resources/js/components/data-table/index.tsx` has been refactored to be generic and reusable. It now supports server-side pagination with `onEachSide(5)`, debounced searching, and filtering by user roles. A "Reset" button has been added to clear active filters.

The `AdminUsersController` has been updated to handle the new filtering and pagination parameters. It now passes the list of available roles to the view for the filter dropdown.

A `Paginated` type has been added to `resources/js/types/index.d.ts` for improved type safety across the application.

This change enhances the user interface for data-heavy pages and improves the overall quality and reusability of the codebase.